### PR TITLE
[docs](docs)Update the spelling error of the BE configuration item allow_invalid_decimalv2_literal in release-1.2.6.md

### DIFF
--- a/docs/zh-CN/docs/releasenotes/release-1.2.6.md
+++ b/docs/zh-CN/docs/releasenotes/release-1.2.6.md
@@ -27,7 +27,7 @@ under the License.
 
 # Behavior Changed
 
-- 新增 BE 配置项 `allow_invalid_decimalv2_triteral` 以控制是否可以导入超过小数精度的 Decimal 类型数据，用于兼容之前的逻辑。
+- 新增 BE 配置项 `allow_invalid_decimalv2_literal` 以控制是否可以导入超过小数精度的 Decimal 类型数据，用于兼容之前的逻辑。
 
 # Bug Fixes
 


### PR DESCRIPTION
Update BE configuration item allow_invalid_decimalv2_triteral in release-1.2.6
allow_invalid_decimalv2_triteral -> allow_invalid_decimalv2_literal

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

